### PR TITLE
#3 move init after config value has been set

### DIFF
--- a/src/AuctionatorEvents.cpp
+++ b/src/AuctionatorEvents.cpp
@@ -8,8 +8,8 @@ AuctionatorEvents::AuctionatorEvents(AuctionatorConfig* auctionatorConfig)
 {
     SetLogPrefix("[AuctionatorEvents] ");
     events = EventMap();
-    InitializeEvents();
     config = auctionatorConfig;
+    InitializeEvents();
 }
 
 AuctionatorEvents::~AuctionatorEvents()


### PR DESCRIPTION
InitializeEvents(); should be called after the config has been set. closes #3

## Changes Proposed:
- init events after config has been set.

## Issues Addressed:
- Closes #3 

## Tests Performed:
- build without errors
- config adjusted to use specific char
- server started
- auctions verified

## How to Test the Changes:
1. follow steps from performed tests
