### PR TITLE
Bugfix nobidvalue

### DIFF
--- a/conf/mod_auctionator.conf.dist
+++ b/conf/mod_auctionator.conf.dist
@@ -76,6 +76,25 @@ Auctionator.Seller.DefaultPrice = 10000000
 Auctionator.Seller.AuctionsPerRun = 100
 
 ########################################
+# Do we want to randomize the size of stacks?
+#
+# 1 - Yes, make stack size somewhere between 1 and the max stack size.
+# 0 - No, make stack size always the max stack size for an item
+########################################
+Auctionator.Seller.RandomizeStackSize = 1
+
+########################################
+# How low do we want to (randomly) start bids at?
+# The default value of .3 means that we will start
+# the bid price of an item between the base price
+# and 30% less than the base price.
+#
+# e.g. if the price of an item is 100 then the
+# start bid price will be somewhere between 70 and 100
+########################################
+Auctionator.Seller.BidStartModify = .3
+
+########################################
 # Allows the bidder to bid on their own auctions.
 # This is useful for testing changes and would also
 # get you more turnover in you auctions.

--- a/conf/mod_auctionator.conf.dist
+++ b/conf/mod_auctionator.conf.dist
@@ -92,7 +92,7 @@ Auctionator.Seller.RandomizeStackSize = 1
 # e.g. if the price of an item is 100 then the
 # start bid price will be somewhere between 70 and 100
 ########################################
-Auctionator.Seller.BidStartModify = .3
+Auctionator.Seller.BidStartModifier = .3
 
 ########################################
 # Allows the bidder to bid on their own auctions.
@@ -107,20 +107,20 @@ Auctionator.Bidder.BidOnOwn = 0
 ########################################
 Auctionator.Multipliers.Seller.Poor = 1.0
 Auctionator.Multipliers.Seller.Normal = 1.0
-Auctionator.Multipliers.Seller.Uncommon = 1.5
-Auctionator.Multipliers.Seller.Rare = 2.0
-Auctionator.Multipliers.Seller.Epic = 6.0
-Auctionator.Multipliers.Seller.Legendary = 10.0
+Auctionator.Multipliers.Seller.Uncommon = 2.0
+Auctionator.Multipliers.Seller.Rare = 6.0
+Auctionator.Multipliers.Seller.Epic = 10.0
+Auctionator.Multipliers.Seller.Legendary = 15.0
 
 ########################################
 # Multipliers for bidder prices
 ########################################
 Auctionator.Multipliers.Bidder.Poor = 1.0
 Auctionator.Multipliers.Bidder.Normal = 1.0
-Auctionator.Multipliers.Bidder.Uncommon = 1.5
-Auctionator.Multipliers.Bidder.Rare = 2.0
-Auctionator.Multipliers.Bidder.Epic = 6.0
-Auctionator.Multipliers.Bidder.Legendary = 10.0
+Auctionator.Multipliers.Bidder.Uncommon = 2.0
+Auctionator.Multipliers.Bidder.Rare = 6.0
+Auctionator.Multipliers.Bidder.Epic = 10.0
+Auctionator.Multipliers.Bidder.Legendary = 15.0
 
 ###################################################################################################
 # LOGGING SYSTEM SETTINGS

--- a/src/Auctionator.cpp
+++ b/src/Auctionator.cpp
@@ -219,6 +219,8 @@ void Auctionator::InitializeConfig(ConfigMgr* configMgr)
     config->sellerConfig.defaultPrice = configMgr->GetOption<uint32>("Auctionator.Seller.DefaultPrice", 10000000);
     config->sellerConfig.queryLimit = 
         configMgr->GetOption<uint32>("Auctionator.Seller.QueryLimit", config->sellerConfig.auctionsPerRun);
+    config->sellerConfig.randomizeStackSize = configMgr->GetOption<uint32>("Auctionator.Seller.RandomizeStackSize", 1);
+    config->sellerConfig.bidStartModifier = configMgr->GetOption<float>("Auctionator.Seller.BidStartModifier", 1.0f);
 
     // Load our bidder configurations
     config->allianceBidder.enabled = configMgr->GetOption<uint32>("Auctionator.AllianceBidder.Enabled", 0);

--- a/src/AuctionatorCommands.cpp
+++ b/src/AuctionatorCommands.cpp
@@ -166,6 +166,8 @@ help
             statusString += "    Auctions per run: " + std::to_string(auctionator->config->sellerConfig.auctionsPerRun) + "\n";
             statusString += "    Query Limit: " + std::to_string(auctionator->config->sellerConfig.queryLimit) + "\n";
             statusString += "    Default Price: " + std::to_string(auctionator->config->sellerConfig.defaultPrice) + "\n";
+            statusString += "    Randomize Stack Size: " + std::to_string(auctionator->config->sellerConfig.randomizeStackSize) + "\n";
+            statusString += "    Bid Start Modifier: " + std::to_string(auctionator->config->sellerConfig.bidStartModifier) + "\n";
 
             handler->SendSysMessage(statusString);
         }

--- a/src/AuctionatorConfig.h
+++ b/src/AuctionatorConfig.h
@@ -36,6 +36,8 @@ struct AuctionatorSellerConfig
         uint32 queryLimit = 1000;
         uint32 defaultPrice = 10000000;
         uint32 auctionsPerRun = 100;
+        uint32 randomizeStackSize = 1;
+        float bidStartModifier = .3;
 };
 
 class AuctionatorConfig

--- a/src/AuctionatorSeller.h
+++ b/src/AuctionatorSeller.h
@@ -16,6 +16,7 @@ class AuctionatorSeller : public AuctionatorBase
         AuctionatorSeller(Auctionator* natorParam, uint32 auctionHouseIdParam);
         ~AuctionatorSeller();
         void LetsGetToIt(uint32 maxCount, uint32 houseId);
+        uint32 GetRandomNumber(uint32 min, uint32 max);
 };
 
 #endif  //AUCTIONATORSELLER_H


### PR DESCRIPTION
Making some quality of life adjustments.

* Items now have a bid attached to them to make it so you can't buy everything for 1 copper if you just bid on it. There is a new config setting `Auctionator.Seller.BidStartModifier` that defaults to .3. This setting means that the bid price will be between the sell price and 30% less than the sell price (selected randomly).
* `Auctionator.Seller.RandomizeStackSize` has been added to allow you to set random stack sizes. Cap is still hard coded to 20 (if you have modified your database to allow larger stacks). If you set this to `1` instead of `0` you will no longer get max stack sizes for every auction, it will be random between 1 and MaxStackSize.
* `.auctionator status` now shows these new settings in the Seller section.
