### PR TITLE
limit stack size based on config

### DIFF
--- a/src/AuctionatorSeller.cpp
+++ b/src/AuctionatorSeller.cpp
@@ -46,7 +46,7 @@ void AuctionatorSeller::LetsGetToIt(uint32 maxCount, uint32 houseId)
             it.entry
             , it.name
             , it.BuyPrice
-            , it.stackable
+            , LEAST(it.stackable, aicconf.stack_count) as stackable
             , it.quality
             , mp.average_price
         FROM


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- This limits the seller item stack size to that from the config table in the db. As far as I can tell, this column was previously unused.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- N/A

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- I noticed glyphs were sold with random stack sizes, which doesn't make sense.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Verified glyphs are posted to AH as single items (not random stack size)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
