### PR TITLE
Improved performance each 60s tick

### DIFF
--- a/data/sql/db-characters/updates/2026_01_29_00_improve_performance.sql
+++ b/data/sql/db-characters/updates/2026_01_29_00_improve_performance.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `idx_itementry` ON `acore_characters`.`item_instance`(`itemEntry`);
+CREATE INDEX `idx_ah_houseid_itemguid` ON `acore_characters`.`auctionhouse`(`houseId`, `itemguid`);

--- a/data/sql/db-characters/updates/2026_01_29_00_improve_performance.sql
+++ b/data/sql/db-characters/updates/2026_01_29_00_improve_performance.sql
@@ -1,2 +1,3 @@
-CREATE INDEX `idx_itementry` ON `acore_characters`.`item_instance`(`itemEntry`);
-CREATE INDEX `idx_ah_houseid_itemguid` ON `acore_characters`.`auctionhouse`(`houseId`, `itemguid`);
+CREATE INDEX idx_ah_houseid_itemguid ON acore_characters.auctionhouse(houseId, itemguid);
+CREATE INDEX idx_ii_guid_entry ON acore_characters.item_instance(guid, itemEntry);
+

--- a/src/AuctionatorSeller.h
+++ b/src/AuctionatorSeller.h
@@ -5,6 +5,16 @@
 #include "Auctionator.h"
 #include "AuctionHouseMgr.h"
 
+struct CachedItem {
+    uint32 entry;
+    std::string name;
+    uint32 basePrice;
+    uint32 stackable;
+    uint32 quality;
+    uint32 marketPrice;
+    uint32 maxCount;
+};
+
 class AuctionatorSeller : public AuctionatorBase
 {
     private:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Each 60 second tick auctionator runs this quite large query. With 15k items on each AH it was taking 0.55s per query.

`.server info` showed a noticeable delay in diffs because of it and if you happend to be performing an action like completing a quest or moving an item to/from your bank it was noticeable.

This takes the `.server info` delay from over 1600ms on each 60s tick where it populates items to **18ms**. 

There are further gains we could make here, by doing each AH in its own tick we could make it 6ms per tick rather than one 18ms delay. But this is far better than the existing implementation

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
