### PR TITLE
feat: Make each AH seller run on its own tick and use in-memory AH rather than query

### DIFF
--- a/data/sql/db-characters/updates/2026_01_29_00_improve_performance.sql
+++ b/data/sql/db-characters/updates/2026_01_29_00_improve_performance.sql
@@ -1,3 +1,0 @@
-CREATE INDEX idx_ah_houseid_itemguid ON acore_characters.auctionhouse(houseId, itemguid);
-CREATE INDEX idx_ii_guid_entry ON acore_characters.item_instance(guid, itemEntry);
-

--- a/src/AuctionatorEvents.cpp
+++ b/src/AuctionatorEvents.cpp
@@ -149,7 +149,7 @@ void AuctionatorEvents::EventNeutralBidder()
 
 void AuctionatorEvents::EventSeller()
 {
-    switch (sellerPhase % 3) {
+    switch (sellerPhase) {
         case 0:
             if (config->allianceSeller.enabled) EventAllianceSeller();
             break;
@@ -160,7 +160,7 @@ void AuctionatorEvents::EventSeller()
             if (config->neutralSeller.enabled) EventNeutralSeller();
             break;
     }
-    sellerPhase++;
+    sellerPhase = (sellerPhase + 1) % 3;
 }
 
 void AuctionatorEvents::EventAllianceSeller()

--- a/src/AuctionatorEvents.cpp
+++ b/src/AuctionatorEvents.cpp
@@ -35,9 +35,7 @@ void AuctionatorEvents::InitializeEvents()
             {1, "AllianceBidder"},
             {2, "HordeBidder"},
             {3, "NeutralBidder"},
-            {4, "AllianceSeller"},
-            {5, "HordeSeller"},
-            {6, "NeutralSeller"}
+            {4, "Seller"},
         };
     //
     // schedule the events for our bidders
@@ -56,16 +54,10 @@ void AuctionatorEvents::InitializeEvents()
         events.ScheduleEvent(3, std::chrono::minutes(config->neutralBidder.cycleMinutes));
     }
 
-    if (config->allianceSeller.enabled) {
+    // Single seller event cycles through Alliance → Horde → Neutral once per
+    // minute, so each house runs every 3 minutes with only one DB query per tick.
+    if (config->allianceSeller.enabled || config->hordeSeller.enabled || config->neutralSeller.enabled) {
         events.ScheduleEvent(4, std::chrono::minutes(1));
-    }
-
-    if (config->hordeSeller.enabled) {
-        events.ScheduleEvent(5, std::chrono::minutes(1));
-    }
-
-    if (config->neutralSeller.enabled) {
-        events.ScheduleEvent(6, std::chrono::minutes(1));
     }
 }
 
@@ -102,20 +94,8 @@ void AuctionatorEvents::ExecuteEvents()
                         }
                         break;
                     case 4:
-                        EventAllianceSeller();
-                        if (config->allianceSeller.enabled) {
-                            events.ScheduleEvent(currentEvent, std::chrono::minutes(1));
-                        }
-                        break;
-                    case 5:
-                        EventHordeSeller();
-                        if (config->hordeSeller.enabled) {
-                            events.ScheduleEvent(currentEvent, std::chrono::minutes(1));
-                        }
-                        break;
-                    case 6:
-                        EventNeutralSeller();
-                        if (config->neutralSeller.enabled) {
+                        EventSeller();
+                        if (config->allianceSeller.enabled || config->hordeSeller.enabled || config->neutralSeller.enabled) {
                             events.ScheduleEvent(currentEvent, std::chrono::minutes(1));
                         }
                         break;
@@ -165,6 +145,22 @@ void AuctionatorEvents::EventNeutralBidder()
     logInfo("Starting Neutral Bidder");
     AuctionatorBidder bidder = AuctionatorBidder((uint32)AuctionHouseId::Neutral, auctionatorGuid, config);
     bidder.SpendSomeCash();
+}
+
+void AuctionatorEvents::EventSeller()
+{
+    switch (sellerPhase % 3) {
+        case 0:
+            if (config->allianceSeller.enabled) EventAllianceSeller();
+            break;
+        case 1:
+            if (config->hordeSeller.enabled) EventHordeSeller();
+            break;
+        case 2:
+            if (config->neutralSeller.enabled) EventNeutralSeller();
+            break;
+    }
+    sellerPhase++;
 }
 
 void AuctionatorEvents::EventAllianceSeller()

--- a/src/AuctionatorEvents.h
+++ b/src/AuctionatorEvents.h
@@ -21,6 +21,7 @@ class AuctionatorEvents : public AuctionatorBase
         std::unordered_map<uint32, std::string> eventToFunction;
         AuctionatorConfig* config;
         AuctionatorHouses* houses;
+        uint32 sellerPhase = 0;
 
     public:
         AuctionatorEvents() {};
@@ -30,6 +31,7 @@ class AuctionatorEvents : public AuctionatorBase
         void EventAllianceBidder();
         void EventHordeBidder();
         void EventNeutralBidder();
+        void EventSeller();
         void EventAllianceSeller();
         void EventHordeSeller();
         void EventNeutralSeller();

--- a/src/AuctionatorSeller.cpp
+++ b/src/AuctionatorSeller.cpp
@@ -3,9 +3,8 @@
 #include "AuctionatorSeller.h"
 #include "Item.h"
 #include "DatabaseEnv.h"
-#include "PreparedStatement.h"
-#include <random>
 #include "QueryResult.h"
+#include <random>
 
 
 AuctionatorSeller::AuctionatorSeller(Auctionator* natorParam, uint32 auctionHouseIdParam)
@@ -24,8 +23,8 @@ AuctionatorSeller::~AuctionatorSeller()
 
 void AuctionatorSeller::LetsGetToIt(uint32 maxCount, uint32 houseId)
 {
-    std::string characterDbName = CharacterDatabase.GetConnectionInfo()->database;
     static std::vector<CachedItem> cachedItems = []() {
+        std::string characterDbName = CharacterDatabase.GetConnectionInfo()->database;
         std::vector<CachedItem> items;
 
         std::string cacheQuery = R"(
@@ -76,24 +75,11 @@ void AuctionatorSeller::LetsGetToIt(uint32 maxCount, uint32 houseId)
     }();
 
 
-    std::string countQuery = R"(
-        SELECT ii.itemEntry, COUNT(*) as itemCount
-        FROM {}.item_instance ii
-        INNER JOIN {}.auctionhouse ah ON ii.guid = ah.itemguid
-        WHERE ah.houseId = {}
-        GROUP BY ii.itemEntry
-    )";
-
-    QueryResult countResult = CharacterDatabase.Query(countQuery, characterDbName, characterDbName, houseId);
-
     std::unordered_map<uint32, uint32> currentCounts;
-    if (countResult)
+    for (auto iter = ahMgr->GetAuctionsBegin(); iter != ahMgr->GetAuctionsEnd(); ++iter)
     {
-        do
-        {
-            Field* fields = countResult->Fetch();
-            currentCounts[fields[0].Get<uint32>()] = fields[1].Get<uint32>();
-        } while (countResult->NextRow());
+        AuctionEntry* auction = iter->second;
+        currentCounts[auction->item_template] += auction->itemCount;
     }
 
     std::vector<CachedItem> shuffled = cachedItems;

--- a/src/AuctionatorSeller.cpp
+++ b/src/AuctionatorSeller.cpp
@@ -76,10 +76,16 @@ void AuctionatorSeller::LetsGetToIt(uint32 maxCount, uint32 houseId)
 
 
     std::unordered_map<uint32, uint32> currentCounts;
-    for (auto iter = ahMgr->GetAuctionsBegin(); iter != ahMgr->GetAuctionsEnd(); ++iter)
+    if (ahMgr)
     {
-        AuctionEntry* auction = iter->second;
-        currentCounts[auction->item_template] += auction->itemCount;
+        for (auto iter = ahMgr->GetAuctionsBegin(); iter != ahMgr->GetAuctionsEnd(); ++iter)
+        {
+            AuctionEntry* auction = iter->second;
+            if (auction)
+            {
+                currentCounts[auction->item_template]++;
+            }
+        }
     }
 
     std::vector<CachedItem> shuffled = cachedItems;


### PR DESCRIPTION
This is a follow up to https://github.com/araxiaonline/mod-auctionator/pull/29

## Changes Proposed:
1. Rather than running all three AH sellers in the same tick it spreads them out, this helps reduce server load each time the seller runs (1/3 load). 
2. Uses the in-memory auction house rather than a DB query to work out what to sell, this is a lot faster since it doesn't block the thread waiting for the DB query to return 

## Tests Performed:
- Built, tested in-game

## How to Test the Changes:
1. Build
2. use to `.auctionator status` to check number of items being sold increases over time

