### PR TITLE
fix: Auctionator crashes azerothcore on startup on most recent crash

### DIFF
--- a/src/Auctionator.cpp
+++ b/src/Auctionator.cpp
@@ -36,7 +36,9 @@ Auctionator::Auctionator()
 };
 
 Auctionator::~Auctionator()
-{}
+{
+    delete session;
+}
 
 void Auctionator::CreateAuction(AuctionatorItem newItem)
 {
@@ -173,7 +175,7 @@ void Auctionator::Initialize()
     NeutralAh = sAuctionMgr->GetAuctionsMapByHouseId(AuctionHouseId::Neutral);
     NeutralAhEntry = sAuctionHouseStore.LookupEntry((uint32)AuctionHouseId::Neutral);
 
-    WorldSession _session(
+    session = new WorldSession(
         config->characterId,
         std::move(accountName),
         0,
@@ -187,8 +189,6 @@ void Auctionator::Initialize()
         false,
         0
     );
-
-    session = &_session;
 }
 
 void Auctionator::InitializeConfig(ConfigMgr* configMgr)

--- a/src/Auctionator.cpp
+++ b/src/Auctionator.cpp
@@ -36,9 +36,7 @@ Auctionator::Auctionator()
 };
 
 Auctionator::~Auctionator()
-{
-    delete session;
-}
+{}
 
 void Auctionator::CreateAuction(AuctionatorItem newItem)
 {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

We create a pointer to session but because it's a local variable it gets destroyed as soon as initialize finishes. We need to clean it up on destructor.

This is currently causing a crash in latest azerothcore on startup because of a recent change to `WorldSession`. This is an existing bug but is now causing a crash

